### PR TITLE
Turned off autocomplete on event date time inputs

### DIFF
--- a/order-form/order-form.html
+++ b/order-form/order-form.html
@@ -40,10 +40,10 @@
             <h2>Event Date and Time Information</h2>
             <p><span>Orders must be placed at least 48 hours prior to the event date, and they can be made 6 months in advance.</span> Delivery times are every half-hour, starting at 10:30 AM and ending at 6:30 PM. All times are Central Standard Time. Please enter your event date and time below.</p>
             <label for="date-picker">Event Date
-                <input id="date-picker" name="event-date" type="date" required title="Select an event date. At least 2 days notice required. Orders can be made up to 6 months in advance."> 
+                <input id="date-picker" name="event-date" type="date" required title="Select an event date. At least 2 days notice required. Orders can be made up to 6 months in advance." autocomplete="off"> 
             </label>
             <label for="time-picker">Event Time
-                <select id="time-picker" name="event-time" required title="Select an event time.">
+                <select id="time-picker" name="event-time" required title="Select an event time." autocomplete="off">
                   <option value=""></option>
                   <option value="10:30">10:30 AM</option>
                   <option value="11:00">11:00 AM</option>


### PR DESCRIPTION
According to StackOverflow, this is supposed to suppress Firefox's caching input values on page reload